### PR TITLE
Add DTO mapping layer for Student endpoints

### DIFF
--- a/src/main/java/com/school/controller/AdminController.java
+++ b/src/main/java/com/school/controller/AdminController.java
@@ -2,6 +2,7 @@ package com.school.controller;
 
 import com.school.model.Admin;
 import com.school.repository.AdminRepository;
+import com.school.dto.AdminDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -22,31 +23,36 @@ public class AdminController {
     }
 
     @GetMapping
-    public List<Admin> list(){ return admins.findAll(); }
+    public List<AdminDto> list(){
+        return admins.findAll().stream().map(AdminDto::from).toList();
+    }
 
     @GetMapping("{id}")
-    public Admin get(@PathVariable Long id){
-        return admins.findById(id)
+    public AdminDto get(@PathVariable Long id){
+        Admin a = admins.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND,"admin "+id+" not found"));
+        return AdminDto.from(a);
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Admin create(@RequestBody Admin body){
+    public AdminDto create(@RequestBody Admin body){
         need(body.getFullName(),"name");
         need(body.getEmail(),"email");
         need(body.getPassword(),"password");
-        return admins.save(body);
+        return AdminDto.from(admins.save(body));
     }
 
     @PutMapping("{id}")
-    public Admin update(@PathVariable Long id,@RequestBody Admin in){
-        Admin a = get(id);
+    public AdminDto update(@PathVariable Long id,@RequestBody Admin in){
+        Admin a = admins.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,"admin "+id+" not found"));
         if(in.getFullName()!=null) a.setFullName(in.getFullName());
         if(in.getEmail()!=null)    a.setEmail(in.getEmail());
         if(in.getPassword()!=null) a.setPassword(in.getPassword());
-        return admins.save(a);
+        return AdminDto.from(admins.save(a));
     }
 
     @DeleteMapping("{id}")

--- a/src/main/java/com/school/controller/AnnouncementController.java
+++ b/src/main/java/com/school/controller/AnnouncementController.java
@@ -2,6 +2,7 @@ package com.school.controller;
 
 import com.school.model.Announcement;
 import com.school.repository.AnnouncementRepository;
+import com.school.dto.AnnouncementDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -16,30 +17,34 @@ public class AnnouncementController {
     public AnnouncementController(AnnouncementRepository repo){ announces = repo; }
 
     @GetMapping
-    public List<Announcement> list(){ return announces.findAll(); }
+    public List<AnnouncementDto> list(){
+        return announces.findAll().stream().map(AnnouncementDto::from).toList();
+    }
 
     @GetMapping("{id}")
-    public Announcement get(@PathVariable Long id){
-        return announces.findById(id)
+    public AnnouncementDto get(@PathVariable Long id){
+        Announcement a = announces.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,"announcement "+id+" not found"));
+        return AnnouncementDto.from(a);
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Announcement create(@RequestBody Announcement body){
+    public AnnouncementDto create(@RequestBody Announcement body){
         if(body.getTitle()==null || body.getTitle().isBlank())
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"title required");
         if(body.getContent()==null || body.getContent().isBlank())
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"content required");
-        return announces.save(body);
+        return AnnouncementDto.from(announces.save(body));
     }
 
     @PutMapping("{id}")
-    public Announcement update(@PathVariable Long id,@RequestBody Announcement in){
-        Announcement a = get(id);
+    public AnnouncementDto update(@PathVariable Long id,@RequestBody Announcement in){
+        Announcement a = announces.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,"announcement "+id+" not found"));
         if(in.getTitle()!=null)   a.setTitle(in.getTitle());
         if(in.getContent()!=null) a.setContent(in.getContent());
-        return announces.save(a);
+        return AnnouncementDto.from(announces.save(a));
     }
 
     @DeleteMapping("{id}")

--- a/src/main/java/com/school/controller/AssignmentController.java
+++ b/src/main/java/com/school/controller/AssignmentController.java
@@ -2,6 +2,7 @@ package com.school.controller;
 
 import com.school.model.Assignment;
 import com.school.repository.AssignmentRepository;
+import com.school.dto.AssignmentDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -16,30 +17,34 @@ public class AssignmentController {
     public AssignmentController(AssignmentRepository repo){ assignments = repo; }
 
     @GetMapping
-    public List<Assignment> list(){ return assignments.findAll(); }
+    public List<AssignmentDto> list(){
+        return assignments.findAll().stream().map(AssignmentDto::from).toList();
+    }
 
     @GetMapping("{id}")
-    public Assignment get(@PathVariable Long id){
-        return assignments.findById(id)
+    public AssignmentDto get(@PathVariable Long id){
+        Assignment a = assignments.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,"assignment "+id+" not found"));
+        return AssignmentDto.from(a);
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Assignment create(@RequestBody Assignment body){
+    public AssignmentDto create(@RequestBody Assignment body){
         if(body.getTitle()==null || body.getTitle().isBlank())
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"title required");
         if(body.getLesson()==null)
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"lesson required");
-        return assignments.save(body);
+        return AssignmentDto.from(assignments.save(body));
     }
 
     @PutMapping("{id}")
-    public Assignment update(@PathVariable Long id,@RequestBody Assignment in){
-        Assignment a = get(id);
+    public AssignmentDto update(@PathVariable Long id,@RequestBody Assignment in){
+        Assignment a = assignments.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,"assignment "+id+" not found"));
         if(in.getTitle()!=null)   a.setTitle(in.getTitle());
         if(in.getDueDate()!=null) a.setDueDate(in.getDueDate());
-        return assignments.save(a);
+        return AssignmentDto.from(assignments.save(a));
     }
 
     @DeleteMapping("{id}")

--- a/src/main/java/com/school/controller/AttendanceController.java
+++ b/src/main/java/com/school/controller/AttendanceController.java
@@ -2,6 +2,7 @@ package com.school.controller;
 
 import com.school.model.Attendance;
 import com.school.repository.AttendanceRepository;
+import com.school.dto.AttendanceDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -28,14 +29,15 @@ public class AttendanceController {
    }
 
     @GetMapping
-    public List<Attendance> listAttendances() {
-        return attendances.findAll();
+    public List<AttendanceDto> listAttendances() {
+        return attendances.findAll().stream().map(AttendanceDto::from).toList();
     }
 
     @GetMapping("{id}")
-    public Attendance getAttendance(@PathVariable Long id) {
-        return attendances.findById(id)
+    public AttendanceDto getAttendance(@PathVariable Long id) {
+        Attendance a = attendances.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "attendance " + id + " not found"));
+        return AttendanceDto.from(a);
     }
 
     @GetMapping("/student/{sid}/percent")
@@ -46,7 +48,7 @@ public class AttendanceController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Attendance createAttendance(@RequestBody Attendance body) {
+    public AttendanceDto createAttendance(@RequestBody Attendance body) {
 
         if (body.getDate() == null)
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "date required");
@@ -60,12 +62,12 @@ public class AttendanceController {
         if (body.getLesson() == null)
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lesson required");
 
-        return attendances.save(body);
+        return AttendanceDto.from(attendances.save(body));
     }
 
     @PostMapping("/bulk")
     @ResponseStatus(HttpStatus.CREATED)
-    public java.util.List<Attendance> bulk(@RequestBody java.util.List<Attendance> list){
+    public java.util.List<AttendanceDto> bulk(@RequestBody java.util.List<Attendance> list){
 
         if(list==null || list.isEmpty())
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"empty payload");
@@ -80,13 +82,14 @@ public class AttendanceController {
             if(a.getStudent()==null || a.getLesson()==null)
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"student & lesson needed");
         }
-        return attendances.saveAll(list);
+        return attendances.saveAll(list).stream().map(AttendanceDto::from).toList();
     }
 
     @PutMapping("{id}")
-    public Attendance updateAttendance(@PathVariable Long id, @RequestBody Attendance in) {
+    public AttendanceDto updateAttendance(@PathVariable Long id, @RequestBody Attendance in) {
 
-        Attendance a = getAttendance(id);
+        Attendance a = attendances.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "attendance " + id + " not found"));
 
         if (in.getStatus() != null) {
             if (!allowed.contains(in.getStatus()))
@@ -98,7 +101,7 @@ public class AttendanceController {
         if (in.getStudent() != null) a.setStudent(in.getStudent());
         if (in.getLesson()  != null) a.setLesson(in.getLesson());
 
-        return attendances.save(a);
+        return AttendanceDto.from(attendances.save(a));
     }
 
     @DeleteMapping("{id}")

--- a/src/main/java/com/school/controller/ExamController.java
+++ b/src/main/java/com/school/controller/ExamController.java
@@ -2,6 +2,7 @@ package com.school.controller;
 
 import com.school.model.Exam;
 import com.school.repository.ExamRepository;
+import com.school.dto.ExamDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -16,30 +17,34 @@ public class ExamController {
     public ExamController(ExamRepository repo){ exams = repo; }
 
     @GetMapping
-    public List<Exam> list(){ return exams.findAll(); }
+    public List<ExamDto> list(){
+        return exams.findAll().stream().map(ExamDto::from).toList();
+    }
 
     @GetMapping("{id}")
-    public Exam get(@PathVariable Long id){
-        return exams.findById(id)
+    public ExamDto get(@PathVariable Long id){
+        Exam e = exams.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,"exam "+id+" not found"));
+        return ExamDto.from(e);
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Exam create(@RequestBody Exam body){
+    public ExamDto create(@RequestBody Exam body){
         if(body.getTitle()==null || body.getTitle().isBlank())
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"title required");
         if(body.getLesson()==null)
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"lesson required");
-        return exams.save(body);
+        return ExamDto.from(exams.save(body));
     }
 
     @PutMapping("{id}")
-    public Exam update(@PathVariable Long id,@RequestBody Exam in){
-        Exam e = get(id);
+    public ExamDto update(@PathVariable Long id,@RequestBody Exam in){
+        Exam e = exams.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,"exam "+id+" not found"));
         if(in.getTitle()!=null)    e.setTitle(in.getTitle());
         if(in.getExamDate()!=null) e.setExamDate(in.getExamDate());
-        return exams.save(e);
+        return ExamDto.from(exams.save(e));
     }
 
     @DeleteMapping("{id}")

--- a/src/main/java/com/school/controller/GradeController.java
+++ b/src/main/java/com/school/controller/GradeController.java
@@ -2,6 +2,7 @@ package com.school.controller;
 
 import com.school.model.Grade;
 import com.school.repository.GradeRepository;
+import com.school.dto.GradeDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -17,28 +18,32 @@ public class GradeController {
 
 
     @GetMapping
-    public List<Grade> list(){ return grades.findAll(); }
+    public List<GradeDto> list(){
+        return grades.findAll().stream().map(g -> new GradeDto(g.getId(), g.getLevel())).toList();
+    }
 
     @GetMapping("{id}")
-    public Grade get(@PathVariable Long id){
-        return grades.findById(id)
+    public GradeDto get(@PathVariable Long id){
+        Grade g = grades.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,"grade "+id+" not found"));
+        return new GradeDto(g.getId(), g.getLevel());
     }
 
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Grade add(@RequestBody Grade body){
+    public GradeDto add(@RequestBody Grade body){
         if(body.getLevel()==null)
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"level required");
-        return grades.save(body);
+        return new GradeDto(grades.save(body).getId(), body.getLevel());
     }
 
     @PutMapping("{id}")
-    public Grade edit(@PathVariable Long id,@RequestBody Grade in){
-        Grade g = get(id);
+    public GradeDto edit(@PathVariable Long id,@RequestBody Grade in){
+        Grade g = grades.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,"grade "+id+" not found"));
         if(in.getLevel()!=null) g.setLevel(in.getLevel());
-        return grades.save(g);
+        return new GradeDto(grades.save(g).getId(), g.getLevel());
     }
 
     @DeleteMapping("{id}")

--- a/src/main/java/com/school/controller/LessonController.java
+++ b/src/main/java/com/school/controller/LessonController.java
@@ -2,6 +2,7 @@ package com.school.controller;
 
 import com.school.model.Lesson;
 import com.school.repository.LessonRepository;
+import com.school.dto.LessonDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -17,27 +18,31 @@ public class LessonController {
     public LessonController(LessonRepository repo){ lessons = repo; }
 
     @GetMapping
-    public List<Lesson> list(){ return lessons.findAll(); }
+    public List<LessonDto> list(){
+        return lessons.findAll().stream().map(LessonDto::from).toList();
+    }
 
     @GetMapping("{id}")
-    public Lesson get(@PathVariable Long id){
-        return lessons.findById(id)
+    public LessonDto get(@PathVariable Long id){
+        Lesson l = lessons.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,"lesson "+id+" not found"));
+        return LessonDto.from(l);
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Lesson add(@RequestBody Lesson body){
+    public LessonDto add(@RequestBody Lesson body){
         if(body.getTopic()==null || body.getTopic().isBlank())
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"topic required");
         if(body.getSubject()==null || body.getTeacher()==null || body.getSchoolClass()==null)
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"subject, teacher and class required");
-        return lessons.save(body);
+        return LessonDto.from(lessons.save(body));
     }
 
     @PutMapping("{id}")
-    public Lesson edit(@PathVariable Long id,@RequestBody Lesson in){
-        Lesson l = get(id);
+    public LessonDto edit(@PathVariable Long id,@RequestBody Lesson in){
+        Lesson l = lessons.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,"lesson "+id+" not found"));
         if(in.getTopic()!=null)       l.setTopic(in.getTopic());
         if(in.getLessonDate()!=null)  l.setLessonDate(in.getLessonDate());
         if(in.getDay()!=null)         l.setDay(in.getDay());
@@ -46,7 +51,7 @@ public class LessonController {
         if(in.getSubject()!=null)     l.setSubject(in.getSubject());
         if(in.getTeacher()!=null)     l.setTeacher(in.getTeacher());
         if(in.getSchoolClass()!=null) l.setSchoolClass(in.getSchoolClass());
-        return lessons.save(l);
+        return LessonDto.from(lessons.save(l));
     }
 
     @DeleteMapping("{id}")

--- a/src/main/java/com/school/controller/ParentController.java
+++ b/src/main/java/com/school/controller/ParentController.java
@@ -2,6 +2,7 @@ package com.school.controller;
 
 import com.school.model.Parent;
 import com.school.repository.ParentRepository;
+import com.school.dto.ParentDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -21,29 +22,33 @@ public class ParentController {
     }
 
     @GetMapping
-    public List<Parent> list(){ return parents.findAll(); }
+    public List<ParentDto> list(){
+        return parents.findAll().stream().map(ParentDto::from).toList();
+    }
 
     @GetMapping("{id}")
-    public Parent get(@PathVariable Long id){
-        return parents.findById(id)
+    public ParentDto get(@PathVariable Long id){
+        Parent p = parents.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,"parent "+id+" not found"));
+        return ParentDto.from(p);
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Parent add(@RequestBody Parent body){
+    public ParentDto add(@RequestBody Parent body){
         must(body.getFullName(),"name");
         must(body.getPassword(),"password");
-        return parents.save(body);
+        return ParentDto.from(parents.save(body));
     }
 
     @PutMapping("{id}")
-    public Parent edit(@PathVariable Long id,@RequestBody Parent in){
-        Parent p = get(id);
+    public ParentDto edit(@PathVariable Long id,@RequestBody Parent in){
+        Parent p = parents.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,"parent "+id+" not found"));
         if(in.getFullName()!=null) p.setFullName(in.getFullName());
         if(in.getEmail()!=null)    p.setEmail(in.getEmail());
         if(in.getPassword()!=null) p.setPassword(in.getPassword());
-        return parents.save(p);
+        return ParentDto.from(parents.save(p));
     }
 
     @DeleteMapping("{id}")

--- a/src/main/java/com/school/controller/ResultController.java
+++ b/src/main/java/com/school/controller/ResultController.java
@@ -2,6 +2,7 @@ package com.school.controller;
 
 import com.school.model.Result;
 import com.school.repository.ResultRepository;
+import com.school.dto.ResultDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -23,12 +24,15 @@ public class ResultController {
 
 
     @GetMapping
-    public List<Result> list(){ return results.findAll(); }
+    public List<ResultDto> list(){
+        return results.findAll().stream().map(ResultDto::from).toList();
+    }
 
     @GetMapping("{id}")
-    public Result get(@PathVariable Long id){
-        return results.findById(id)
+    public ResultDto get(@PathVariable Long id){
+        Result r = results.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,"result "+id+" not found"));
+        return ResultDto.from(r);
     }
 
     @GetMapping("/student/{id}/average")
@@ -45,19 +49,20 @@ public class ResultController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Result create(@RequestBody Result body){
+    public ResultDto create(@RequestBody Result body){
         if(body.getScore()==null)
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"score required");
         if(body.getStudent()==null || body.getExam()==null)
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"student and exam required");
-        return results.save(body);
+        return ResultDto.from(results.save(body));
     }
 
     @PutMapping("{id}")
-    public Result update(@PathVariable Long id,@RequestBody Result in){
-        Result r = get(id);
+    public ResultDto update(@PathVariable Long id,@RequestBody Result in){
+        Result r = results.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,"result "+id+" not found"));
         if(in.getScore()!=null) r.setScore(in.getScore());
-        return results.save(r);
+        return ResultDto.from(results.save(r));
     }
 
     @DeleteMapping("{id}")

--- a/src/main/java/com/school/controller/SchoolClassController.java
+++ b/src/main/java/com/school/controller/SchoolClassController.java
@@ -2,6 +2,8 @@ package com.school.controller;
 
 import com.school.model.SchoolClass;
 import com.school.repository.SchoolClassRepository;
+import com.school.dto.SchoolClassDto;
+import com.school.dto.GradeDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -25,12 +27,19 @@ public class SchoolClassController {
 
 
     @GetMapping
-    public List<SchoolClass> list(){ return classes.findAll(); }
+    public List<SchoolClassDto> list(){
+        return classes.findAll().stream()
+                .map(c -> new SchoolClassDto(c.getId(), c.getName(),
+                        (c.getGrade()!=null)? new GradeDto(c.getGrade().getId(), c.getGrade().getLevel()) : null))
+                .toList();
+    }
 
     @GetMapping("{id}")
-    public SchoolClass get(@PathVariable Long id){
-        return classes.findById(id)
+    public SchoolClassDto get(@PathVariable Long id){
+        SchoolClass c = classes.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,"class "+id+" not found"));
+        GradeDto gd = (c.getGrade()!=null)? new GradeDto(c.getGrade().getId(), c.getGrade().getLevel()) : null;
+        return new SchoolClassDto(c.getId(), c.getName(), gd);
     }
 
     @GetMapping("{id}/rank")
@@ -41,22 +50,27 @@ public class SchoolClassController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public SchoolClass create(@RequestBody SchoolClass body){
+    public SchoolClassDto create(@RequestBody SchoolClass body){
         if(body.getName()==null||body.getName().isBlank())
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"name required");
         if(body.getGrade()==null)
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"grade required");
-        return classes.save(body);
+        SchoolClass saved = classes.save(body);
+        GradeDto gd = (saved.getGrade()!=null)? new GradeDto(saved.getGrade().getId(), saved.getGrade().getLevel()) : null;
+        return new SchoolClassDto(saved.getId(), saved.getName(), gd);
     }
 
     @PutMapping("{id}")
-    public SchoolClass update(@PathVariable Long id,@RequestBody SchoolClass in){
-        SchoolClass c = get(id);
+    public SchoolClassDto update(@PathVariable Long id,@RequestBody SchoolClass in){
+        SchoolClass c = classes.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,"class "+id+" not found"));
         if(in.getName()!=null)     c.setName(in.getName());
         if(in.getCapacity()!=null) c.setCapacity(in.getCapacity());
         if(in.getGrade()!=null)    c.setGrade(in.getGrade());
         if(in.getSupervisor()!=null)c.setSupervisor(in.getSupervisor());
-        return classes.save(c);
+        SchoolClass saved = classes.save(c);
+        GradeDto gd = (saved.getGrade()!=null)? new GradeDto(saved.getGrade().getId(), saved.getGrade().getLevel()) : null;
+        return new SchoolClassDto(saved.getId(), saved.getName(), gd);
     }
 
     @DeleteMapping("{id}")

--- a/src/main/java/com/school/controller/StudentController.java
+++ b/src/main/java/com/school/controller/StudentController.java
@@ -1,96 +1,83 @@
 package com.school.controller;
 
+import com.school.dto.*;
 import com.school.model.Student;
-import com.school.repository.StudentRepository;
+import com.school.repository.*;
+import com.school.service.AttendanceService;
+import com.school.service.StudentService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
-import com.school.service.StudentService;
-import com.school.service.AttendanceService;
-import java.util.Map;
-
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/students")
 public class StudentController {
-    private final StudentService moves;
-    private final AttendanceService attendanceSvc;
-    private final StudentRepository students;
-    
-    public StudentController(StudentRepository repo, StudentService svc, AttendanceService as) {  
-        this.students = repo;
-        this.moves    = svc;
-        this.attendanceSvc = as;
+
+    private final StudentRepository     students;
+    private final SchoolClassRepository classes;
+    private final StudentService        moves;
+    private final AttendanceService     attendanceSvc;
+
+    public StudentController(StudentRepository     students,
+                             SchoolClassRepository classes,
+                             StudentService        moves,
+                             AttendanceService     attendanceSvc) {
+        this.students      = students;
+        this.classes       = classes;
+        this.moves         = moves;
+        this.attendanceSvc = attendanceSvc;
     }
-
-   //method for validating informations
-    private static void require(String value, String field) {
-        if (value == null || value.isBlank())
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, field + " required");
-    }
-
-
 
     //Methods
     @GetMapping
-    public List<Student> listStudents() {
-        return students.findAll();
+    public List<StudentDto> list() {
+        return students.findAll()
+                       .stream()
+                       .map(StudentMapper::toDto)
+                       .toList();
     }
 
     @GetMapping("{id}")
-    public Student getStudent(@PathVariable Long id) {
-        return students.findById(id)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "student " + id + " not found"));
+    public StudentDto get(@PathVariable Long id) {
+        Student s = students.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "student not found"));
+        return StudentMapper.toDto(s);
     }
 
     @GetMapping("{id}/attendance/percentage")
     public Map<String, Object> percentage(@PathVariable Long id) {
-        getStudent(id);                       // ensures student exists
+        get(id);                       // ensures student exists
         return attendanceSvc.percentForStudent(id);
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Student createStudent(@RequestBody Student body) {
+    public StudentDto create(@RequestBody StudentDto body) {
 
-        require(body.getFullName(), "name");
-        require(body.getEmail(),     "email");
-        require(body.getPassword(),  "password");
-
-        if (!body.getEmail().contains("@"))
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "invalid email");
-
-        if (body.getSchoolClass() == null)
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "class required");
-
-        return students.save(body);
+        Student newEntity = new Student();
+        StudentMapper.copyOnWrite(body, newEntity, classes);
+        return StudentMapper.toDto(students.save(newEntity));
     }
 
     @PutMapping("{id}")
-    public Student updateStudent(@PathVariable Long id, @RequestBody Student in) {
+    public StudentDto update(@PathVariable Long id,
+                             @RequestBody StudentDto in) {
 
-        Student s = getStudent(id);
+        Student entity = students.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "student not found"));
 
-        if (in.getFullName() != null)  s.setFullName(in.getFullName());
-        if (in.getSurname()  != null)  s.setSurname(in.getSurname());
-        if (in.getEmail()    != null) {
-            if (!in.getEmail().contains("@"))
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "invalid email");
-            s.setEmail(in.getEmail());
-        }
-        if (in.getPassword() != null)  s.setPassword(in.getPassword());
-        if (in.getSchoolClass()!=null) s.setSchoolClass(in.getSchoolClass());
-
-        return students.save(s);
+        StudentMapper.copyOnWrite(in, entity, classes);
+        return StudentMapper.toDto(students.save(entity));
     }
 
     @PutMapping("{id}/class/{targetId}")
-    public Student reclass(
+    public StudentDto reclass(
             @PathVariable Long id,
             @PathVariable("targetId") Long newClass) {
 
-        return moves.move(id, newClass);
+        return StudentMapper.toDto(moves.move(id, newClass));
     }
 
     @DeleteMapping("{id}")

--- a/src/main/java/com/school/controller/SubjectController.java
+++ b/src/main/java/com/school/controller/SubjectController.java
@@ -2,6 +2,7 @@ package com.school.controller;
 
 import com.school.model.Subject;
 import com.school.repository.SubjectRepository;
+import com.school.dto.SubjectDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -16,27 +17,31 @@ public class SubjectController {
     public SubjectController(SubjectRepository repo){ this.subjects = repo; }
 
     @GetMapping
-    public List<Subject> list(){ return subjects.findAll(); }
+    public List<SubjectDto> list(){
+        return subjects.findAll().stream().map(SubjectDto::from).toList();
+    }
 
     @GetMapping("{id}")
-    public Subject get(@PathVariable Long id){
-        return subjects.findById(id)
+    public SubjectDto get(@PathVariable Long id){
+        Subject s = subjects.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,"subject "+id+" not found"));
+        return SubjectDto.from(s);
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Subject add(@RequestBody Subject body){
+    public SubjectDto add(@RequestBody Subject body){
         if(body.getName()==null || body.getName().isBlank())
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"name required");
-        return subjects.save(body);
+        return SubjectDto.from(subjects.save(body));
     }
 
     @PutMapping("{id}")
-    public Subject edit(@PathVariable Long id,@RequestBody Subject in){
-        Subject s = get(id);
+    public SubjectDto edit(@PathVariable Long id,@RequestBody Subject in){
+        Subject s = subjects.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,"subject "+id+" not found"));
         if(in.getName()!=null) s.setName(in.getName());
-        return subjects.save(s);
+        return SubjectDto.from(subjects.save(s));
     }
 
     @DeleteMapping("{id}")

--- a/src/main/java/com/school/controller/TeacherController.java
+++ b/src/main/java/com/school/controller/TeacherController.java
@@ -2,6 +2,7 @@ package com.school.controller;
 
 import com.school.model.Teacher;
 import com.school.repository.TeacherRepository;
+import com.school.dto.TeacherDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -26,19 +27,20 @@ public class TeacherController {
 
 
     @GetMapping
-    public List<Teacher> listTeachers() {
-        return teachers.findAll();
+    public List<TeacherDto> listTeachers() {
+        return teachers.findAll().stream().map(TeacherDto::from).toList();
     }
 
     @GetMapping("{id}")
-    public Teacher getTeacher(@PathVariable Long id) {
-        return teachers.findById(id)
+    public TeacherDto getTeacher(@PathVariable Long id) {
+        Teacher t = teachers.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "teacher " + id + " not found"));
+        return TeacherDto.from(t);
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Teacher addTeacher(@RequestBody Teacher body) {
+    public TeacherDto addTeacher(@RequestBody Teacher body) {
 
         need(body.getFullName(), "name");
         need(body.getPassword(), "password");
@@ -49,13 +51,14 @@ public class TeacherController {
         if (body.getEmail() != null && !body.getEmail().contains("@"))
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "invalid email");
 
-        return teachers.save(body);
+        return TeacherDto.from(teachers.save(body));
     }
 
     @PutMapping("{id}")
-    public Teacher updateTeacher(@PathVariable Long id, @RequestBody Teacher in) {
+    public TeacherDto updateTeacher(@PathVariable Long id, @RequestBody Teacher in) {
 
-        Teacher t = getTeacher(id);
+        Teacher t = teachers.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "teacher " + id + " not found"));
 
         if (in.getFullName() != null) t.setFullName(in.getFullName());
 
@@ -68,7 +71,7 @@ public class TeacherController {
         if (in.getPassword() != null) t.setPassword(in.getPassword());
         if (in.getSubject()  != null) t.setSubject(in.getSubject());
 
-        return teachers.save(t);
+        return TeacherDto.from(teachers.save(t));
     }
 
     @DeleteMapping("{id}")

--- a/src/main/java/com/school/dto/AdminDto.java
+++ b/src/main/java/com/school/dto/AdminDto.java
@@ -1,0 +1,9 @@
+package com.school.dto;
+
+import com.school.model.Admin;
+
+public record AdminDto(Long id, String fullName, String email) {
+    public static AdminDto from(Admin a) {
+        return new AdminDto(a.getId(), a.getFullName(), a.getEmail());
+    }
+}

--- a/src/main/java/com/school/dto/AnnouncementDto.java
+++ b/src/main/java/com/school/dto/AnnouncementDto.java
@@ -1,0 +1,14 @@
+package com.school.dto;
+
+import com.school.model.Announcement;
+
+import java.time.LocalDateTime;
+
+public record AnnouncementDto(Long id, String title, String content,
+                              LocalDateTime publishedAt, Long classId) {
+    public static AnnouncementDto from(Announcement a) {
+        Long cid = (a.getSchoolClass() != null) ? a.getSchoolClass().getId() : null;
+        return new AnnouncementDto(a.getId(), a.getTitle(), a.getContent(),
+                a.getPublishedAt(), cid);
+    }
+}

--- a/src/main/java/com/school/dto/AssignmentDto.java
+++ b/src/main/java/com/school/dto/AssignmentDto.java
@@ -1,0 +1,12 @@
+package com.school.dto;
+
+import com.school.model.Assignment;
+
+import java.time.LocalDate;
+
+public record AssignmentDto(Long id, String title, LocalDate dueDate, Long lessonId) {
+    public static AssignmentDto from(Assignment a) {
+        Long lid = (a.getLesson() != null) ? a.getLesson().getId() : null;
+        return new AssignmentDto(a.getId(), a.getTitle(), a.getDueDate(), lid);
+    }
+}

--- a/src/main/java/com/school/dto/AttendanceDto.java
+++ b/src/main/java/com/school/dto/AttendanceDto.java
@@ -1,0 +1,14 @@
+package com.school.dto;
+
+import com.school.model.Attendance;
+
+import java.time.LocalDate;
+
+public record AttendanceDto(Long id, LocalDate date, String status,
+                            Long studentId, Long lessonId) {
+    public static AttendanceDto from(Attendance a) {
+        Long sid = (a.getStudent() != null) ? a.getStudent().getId() : null;
+        Long lid = (a.getLesson()  != null) ? a.getLesson().getId()  : null;
+        return new AttendanceDto(a.getId(), a.getDate(), a.getStatus(), sid, lid);
+    }
+}

--- a/src/main/java/com/school/dto/ExamDto.java
+++ b/src/main/java/com/school/dto/ExamDto.java
@@ -1,0 +1,12 @@
+package com.school.dto;
+
+import com.school.model.Exam;
+
+import java.time.LocalDate;
+
+public record ExamDto(Long id, String title, LocalDate examDate, Long lessonId) {
+    public static ExamDto from(Exam e) {
+        Long lid = (e.getLesson() != null) ? e.getLesson().getId() : null;
+        return new ExamDto(e.getId(), e.getTitle(), e.getExamDate(), lid);
+    }
+}

--- a/src/main/java/com/school/dto/GradeDto.java
+++ b/src/main/java/com/school/dto/GradeDto.java
@@ -1,0 +1,3 @@
+package com.school.dto;
+
+public record GradeDto(Long id, Integer level) {}

--- a/src/main/java/com/school/dto/LessonDto.java
+++ b/src/main/java/com/school/dto/LessonDto.java
@@ -1,0 +1,18 @@
+package com.school.dto;
+
+import com.school.model.Lesson;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record LessonDto(Long id, String topic, LocalDate lessonDate, String day,
+                        LocalTime startTime, LocalTime endTime,
+                        Long subjectId, Long teacherId, Long classId) {
+    public static LessonDto from(Lesson l) {
+        Long sid = (l.getSubject() != null) ? l.getSubject().getId() : null;
+        Long tid = (l.getTeacher() != null) ? l.getTeacher().getId() : null;
+        Long cid = (l.getSchoolClass() != null) ? l.getSchoolClass().getId() : null;
+        return new LessonDto(l.getId(), l.getTopic(), l.getLessonDate(), l.getDay(),
+                l.getStartTime(), l.getEndTime(), sid, tid, cid);
+    }
+}

--- a/src/main/java/com/school/dto/ParentDto.java
+++ b/src/main/java/com/school/dto/ParentDto.java
@@ -1,0 +1,11 @@
+package com.school.dto;
+
+import com.school.model.Parent;
+
+public record ParentDto(Long id, String fullName, String phone,
+                        String email, String address) {
+    public static ParentDto from(Parent p) {
+        return new ParentDto(p.getId(), p.getFullName(), p.getPhone(),
+                p.getEmail(), p.getAddress());
+    }
+}

--- a/src/main/java/com/school/dto/ResultDto.java
+++ b/src/main/java/com/school/dto/ResultDto.java
@@ -1,0 +1,11 @@
+package com.school.dto;
+
+import com.school.model.Result;
+
+public record ResultDto(Long id, Double score, Long studentId, Long examId) {
+    public static ResultDto from(Result r) {
+        Long sid = (r.getStudent() != null) ? r.getStudent().getId() : null;
+        Long eid = (r.getExam() != null) ? r.getExam().getId() : null;
+        return new ResultDto(r.getId(), r.getScore(), sid, eid);
+    }
+}

--- a/src/main/java/com/school/dto/SchoolClassDto.java
+++ b/src/main/java/com/school/dto/SchoolClassDto.java
@@ -1,0 +1,3 @@
+package com.school.dto;
+
+public record SchoolClassDto(Long id, String name, GradeDto grade) {}

--- a/src/main/java/com/school/dto/StudentDto.java
+++ b/src/main/java/com/school/dto/StudentDto.java
@@ -1,0 +1,9 @@
+package com.school.dto;
+
+/** What the client gets/produces – no Hibernate, no password */
+public record StudentDto(
+        Long id,
+        String fullName,
+        String email,
+        SchoolClassDto schoolClass
+) {}

--- a/src/main/java/com/school/dto/StudentMapper.java
+++ b/src/main/java/com/school/dto/StudentMapper.java
@@ -1,0 +1,35 @@
+package com.school.dto;
+
+import com.school.model.*;
+import com.school.repository.SchoolClassRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public final class StudentMapper {
+
+    public static StudentDto toDto(Student s) {
+        Grade g = (s.getSchoolClass() != null) ? s.getSchoolClass().getGrade() : null;
+        GradeDto gd = (g == null) ? null : new GradeDto(g.getId(), g.getLevel());
+
+        SchoolClass c = s.getSchoolClass();
+        SchoolClassDto cd = (c == null) ? null : new SchoolClassDto(c.getId(), c.getName(), gd);
+
+        return new StudentDto(s.getId(), s.getFullName(), s.getEmail(), cd);
+    }
+
+    public static void copyOnWrite(StudentDto dto,
+                                   Student target,
+                                   SchoolClassRepository classes) {
+        if (dto.fullName() != null) target.setFullName(dto.fullName());
+        if (dto.email() != null) target.setEmail(dto.email());
+
+        if (dto.schoolClass() != null && dto.schoolClass().id() != null) {
+            SchoolClass c = classes.findById(dto.schoolClass().id())
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "class not found"));
+            target.setSchoolClass(c);
+        }
+    }
+
+    private StudentMapper() {}
+}

--- a/src/main/java/com/school/dto/SubjectDto.java
+++ b/src/main/java/com/school/dto/SubjectDto.java
@@ -1,0 +1,9 @@
+package com.school.dto;
+
+import com.school.model.Subject;
+
+public record SubjectDto(Long id, String name) {
+    public static SubjectDto from(Subject s) {
+        return new SubjectDto(s.getId(), s.getName());
+    }
+}

--- a/src/main/java/com/school/dto/TeacherDto.java
+++ b/src/main/java/com/school/dto/TeacherDto.java
@@ -1,0 +1,15 @@
+package com.school.dto;
+
+import com.school.model.Teacher;
+
+import java.time.LocalDate;
+
+public record TeacherDto(Long id, String fullName, String email, String phone,
+                         String img, String bloodType, String sex,
+                         LocalDate birthday, Long subjectId) {
+    public static TeacherDto from(Teacher t) {
+        Long sid = (t.getSubject() != null) ? t.getSubject().getId() : null;
+        return new TeacherDto(t.getId(), t.getFullName(), t.getEmail(), t.getPhone(),
+                t.getImg(), t.getBloodType(), t.getSex(), t.getBirthday(), sid);
+    }
+}


### PR DESCRIPTION
## Summary
- implement DTO classes for Grade, SchoolClass and Student
- add a mapper for converting between Student entities and DTOs
- refactor StudentController to expose DTOs instead of JPA entities
- return DTOs from remaining controllers to avoid lazy proxy issues

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*